### PR TITLE
Switch interval setting to be more human friendly

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.sleeptimer"
        name="Sleep Timer"
-      version="2.0.9"
+      version="2.0.10"
       provider-name="enen92, Solo0815">
     <requires>
 		<import addon="xbmc.addon" version="14.0.0"/>

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -39,7 +39,7 @@ msgid "General"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Time between 1% volume change  (millisec)"
+msgid "Time it takes to reach 0% volume (minutes)"
 msgstr ""
 
 msgctxt "#30007"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -129,3 +129,7 @@ msgstr ""
 msgctxt "#30028"
 msgid "Specific Time"
 msgstr ""
+
+msgctxt "#30029"
+msgid "Set the minimum volume %"
+msgstr ""

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -38,8 +38,8 @@ msgid "General"
 msgstr "Geral"
 
 msgctxt "#30006"
-msgid "Time between 1% volume change  (millisec)"
-msgstr "Tempo entre a alteração de 1% volume (millisec)"
+msgid "Time it takes to reach 0% volume (minutes)"
+msgstr "Tempo que leva para atingir o volume de 0% (minutos)"
 
 msgctxt "#30007"
 msgid "Next check time if dialog is cancelled (minutes)"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -128,3 +128,7 @@ msgstr "Sempre"
 msgctxt "#30028"
 msgid "Specific Time"
 msgstr "Tempo especifico"
+
+msgctxt "#30029"
+msgid "Set the minimum volume %"
+msgstr "Defina o volume mínimo %"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,7 +4,7 @@
 		<setting id="check_time" label="30002" default="5" type="slider" range="1,5,120" option="int"/>
 		<setting id="waiting_time_dialog" label="30003" type="slider" default="60" range="30,5,180" option="int"/>
 		<setting id="audio_change" label="30004" type="bool" default="true" visible="true"/>
-		<setting id="audio_change_rate" label="30006" enable="eq(-1,true)" type="slider" default="500" range="50,50,3000" option="int"/>
+		<setting id="audio_interval_length" label="30006" enable="eq(-1,true)" type="slider" default="1" range="1,1,120" option="int"/>
 		<setting id="check_time_next" label="30007" type="slider" default="30" range="15,10,120" option="int"/>
 		<setting id="enable_screensaver" label="30008" type="bool" default="false" visible="true"/>
 	     <setting id="custom_cmd" label="30022" type="bool" default="false" visible="true"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,6 +5,7 @@
 		<setting id="waiting_time_dialog" label="30003" type="slider" default="60" range="30,5,180" option="int"/>
 		<setting id="audio_change" label="30004" type="bool" default="true" visible="true"/>
 		<setting id="audio_interval_length" label="30006" enable="eq(-1,true)" type="slider" default="1" range="1,1,120" option="int"/>
+		<setting id="mute_volume" label="30029" enable="eq(-2,true)" type="slider" default="10" range="1,1,100" visible="true" option="int"/>
 		<setting id="check_time_next" label="30007" type="slider" default="30" range="15,10,120" option="int"/>
 		<setting id="enable_screensaver" label="30008" type="bool" default="false" visible="true"/>
 	     <setting id="custom_cmd" label="30022" type="bool" default="false" visible="true"/>

--- a/service.py
+++ b/service.py
@@ -39,6 +39,7 @@ check_time = selfAddon.getSetting('check_time')
 check_time_next = int(selfAddon.getSetting('check_time_next'))
 time_to_wait = int(selfAddon.getSetting('waiting_time_dialog'))
 audiochange = selfAddon.getSetting('audio_change')
+muteVol = int(selfAddon.getSetting('mute_volume'))
 audiointervallength = int(selfAddon.getSetting('audio_interval_length'))
 global audio_enable
 audio_enable = str(selfAddon.getSetting('audio_enable'))
@@ -261,7 +262,6 @@ class service:
                             if audiochange == 'true':
                                 resp = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Application.GetProperties", "params": { "properties": [ "volume"] }, "id": 1}')
                                 dct = json.loads(resp)
-                                muteVol = 10
 
                                 if ("result" in dct) and ("volume" in dct["result"]):
                                     curVol = dct["result"]["volume"]

--- a/service.py
+++ b/service.py
@@ -268,8 +268,9 @@ class service:
 
                                     for i in range(curVol - 1, muteVol - 1, -1):
                                         xbmc.executebuiltin('SetVolume(%d,showVolumeBar)' % (i))
-                                        # move down slowly
-                                        xbmc.sleep(audiointervallength * 600)
+                                        # move down slowly ((total mins / steps) * ms in a min)
+                                        # (curVol-muteVol) runs the full timer where a user might control their volume via kodi instead of cutting it short when assuming a set volume of 100%
+                                        xbmc.sleep(round(audiointervallength / (curVol - muteVol) * 60000))
 
                             # stop player anyway
                             monitor.waitForAbort(5) # wait 5s before stopping

--- a/service.py
+++ b/service.py
@@ -39,7 +39,7 @@ check_time = selfAddon.getSetting('check_time')
 check_time_next = int(selfAddon.getSetting('check_time_next'))
 time_to_wait = int(selfAddon.getSetting('waiting_time_dialog'))
 audiochange = selfAddon.getSetting('audio_change')
-audiochangerate = int(selfAddon.getSetting('audio_change_rate'))
+audiointervallength = int(selfAddon.getSetting('audio_interval_length'))
 global audio_enable
 audio_enable = str(selfAddon.getSetting('audio_enable'))
 video_enable = str(selfAddon.getSetting('video_enable'))
@@ -269,7 +269,7 @@ class service:
                                     for i in range(curVol - 1, muteVol - 1, -1):
                                         xbmc.executebuiltin('SetVolume(%d,showVolumeBar)' % (i))
                                         # move down slowly
-                                        xbmc.sleep(audiochangerate)
+                                        xbmc.sleep(audiointervallength * 600)
 
                             # stop player anyway
                             monitor.waitForAbort(5) # wait 5s before stopping


### PR DESCRIPTION
How long did 3000ms interval take before? Who cares about the interval itself. 
I find this method of setting the interval to be a lot better for humans. Humans are more concerned with how long the interval will run.  
This also has the benefit of a shorter slider (1 to 120 instead of 50 to 3000) while allowing a longer timer (max of 2 hours instead of a max of 50 mins)

Unsure about Portuguese string. I used google translate. 